### PR TITLE
docs: fix build number terminology

### DIFF
--- a/healthy_budget_coach/pubspec.yaml
+++ b/healthy_budget_coach/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
 # followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
+# Both the version and the build number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # In Android, build-name is used as versionName while build-number used as versionCode.
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning


### PR DESCRIPTION
## Summary
- fix build number terminology in pubspec.yaml comment

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc5b9cd24832aba0dea0424c824e7