### PR TITLE
Align SDK requirement for Flutter tests

### DIFF
--- a/healthy_budget_coach/pubspec.lock
+++ b/healthy_budget_coach/pubspec.lock
@@ -209,5 +209,5 @@ packages:
     source: hosted
     version: "14.2.5"
 sdks:
-  dart: ">=3.5.4 <4.0.0"
+  dart: ">=3.5.3 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/healthy_budget_coach/pubspec.yaml
+++ b/healthy_budget_coach/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.5.4
+  sdk: ">=3.5.3 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
## Summary
- adjust SDK constraint to allow Dart 3.5.3
- update lockfile to match new SDK requirement

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68adcc6281a8832abae68b8984e4726a