### PR TITLE
test: verify multiple increments

### DIFF
--- a/healthy_budget_coach/test/widget_test.dart
+++ b/healthy_budget_coach/test/widget_test.dart
@@ -26,5 +26,13 @@ void main() {
     // Verify that our counter has incremented.
     expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
+
+    // Tap the '+' icon again and trigger another frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    // Verify that our counter has incremented to 2.
+    expect(find.text('1'), findsNothing);
+    expect(find.text('2'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- extend counter widget test to tap twice and ensure counter shows 2

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `snap install flutter --classic` *(fails: command not found: snap)*

------
https://chatgpt.com/codex/tasks/task_e_68adc5f0a6c0832ab481c1101e52c123