### PR TITLE
Implement Material 3 UI scaffolding with mock data

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+- Added Material 3 theme with dynamic color fallback and typography.
+- Introduced simple app router and formatter utilities.
+- Created mock repositories and data models for deals, meals, and workouts.
+- Built new widgets (budget meter, price chip, meal/workout cards, empty/error states, shimmer box, swap sheet, coach card).
+- Implemented dashboard, meals, deals, workouts, and assistant screens wired to repositories.
+- Updated pubspec with intl dependency.
+
+## Next Steps
+- Replace mock repositories with real data sources.
+- Expand swap sheet animations and search/filter logic.

--- a/healthy_budget_coach/lib/core/ui/app_router.dart
+++ b/healthy_budget_coach/lib/core/ui/app_router.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../../ui/screens/screen_dashboard.dart';
+import '../../ui/screens/screen_meals.dart';
+import '../../ui/screens/screen_deals.dart';
+import '../../ui/screens/screen_workouts.dart';
+import '../../ui/screens/screen_assistant.dart';
+
+enum AppRoute { dashboard, meals, deals, workouts, assistant }
+
+class AppRouter {
+  static Route<dynamic> onGenerateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case '/':
+      case 'dashboard':
+        return _build(const DashboardScreen());
+      case 'meals':
+        return _build(const MealsScreen());
+      case 'deals':
+        return _build(const DealsScreen());
+      case 'workouts':
+        return _build(const WorkoutsScreen());
+      case 'assistant':
+        return _build(const AssistantScreen());
+      default:
+        return _build(const DashboardScreen());
+    }
+  }
+
+  static MaterialPageRoute _build(Widget child) =>
+      MaterialPageRoute(builder: (_) => child);
+}

--- a/healthy_budget_coach/lib/core/ui/formatters.dart
+++ b/healthy_budget_coach/lib/core/ui/formatters.dart
@@ -1,0 +1,16 @@
+import 'package:intl/intl.dart';
+
+String priceFormatter(num value) {
+  final format = NumberFormat.currency(locale: 'en_US');
+  return format.format(value);
+}
+
+String macroFormatter(num grams, String macro) {
+  final format = NumberFormat.decimalPattern();
+  return '${format.format(grams)} g $macro';
+}
+
+String kcalFormatter(num kcal) {
+  final format = NumberFormat.decimalPattern();
+  return '${format.format(kcal)} kcal';
+}

--- a/healthy_budget_coach/lib/data/mock_data.dart
+++ b/healthy_budget_coach/lib/data/mock_data.dart
@@ -1,0 +1,55 @@
+class Deal {
+  final String store;
+  final String item;
+  final double price;
+  final double? oldPrice;
+  const Deal({
+    required this.store,
+    required this.item,
+    required this.price,
+    this.oldPrice,
+  });
+}
+
+class Meal {
+  final String name;
+  final double price;
+  final int protein;
+  final int calories;
+  final List<String> tags;
+  const Meal({
+    required this.name,
+    required this.price,
+    required this.protein,
+    required this.calories,
+    this.tags = const [],
+  });
+}
+
+class Workout {
+  final String title;
+  final String goal;
+  final int minutes;
+  final int intensity; // 1-3
+  const Workout({
+    required this.title,
+    required this.goal,
+    required this.minutes,
+    required this.intensity,
+  });
+}
+
+final mockDeals = <Deal>[
+  Deal(store: 'Market', item: 'Apples', price: 2.5, oldPrice: 3.0),
+  Deal(store: 'Shop', item: 'Oats', price: 4.0),
+];
+
+final mockMeals = <Meal>[
+  Meal(name: 'Chicken Salad', price: 5.5, protein: 30, calories: 320, tags: ['quick']),
+  Meal(name: 'Veggie Bowl', price: 4.2, protein: 15, calories: 280, tags: ['veggie']),
+];
+
+final mockWorkouts = <Workout>[
+  Workout(title: 'HIIT Blast', goal: 'Fat loss', minutes: 20, intensity: 3),
+  Workout(title: 'Yoga Flow', goal: 'Recovery', minutes: 30, intensity: 1),
+];

--- a/healthy_budget_coach/lib/data/repositories/deals_repository.dart
+++ b/healthy_budget_coach/lib/data/repositories/deals_repository.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import '../mock_data.dart';
+
+class DealsRepository {
+  Future<List<Deal>> fetchDeals() async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return mockDeals;
+  }
+
+  Future<List<Deal>> refresh() async => fetchDeals();
+
+  Future<Map<String, List<Deal>>> groupByStore() async {
+    final deals = await fetchDeals();
+    final map = <String, List<Deal>>{};
+    for (final d in deals) {
+      map.putIfAbsent(d.store, () => []).add(d);
+    }
+    return map;
+  }
+}

--- a/healthy_budget_coach/lib/data/repositories/meals_repository.dart
+++ b/healthy_budget_coach/lib/data/repositories/meals_repository.dart
@@ -1,0 +1,18 @@
+import '../mock_data.dart';
+
+class MealsRepository {
+  Stream<List<Meal>> listMeals() async* {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    yield mockMeals;
+  }
+
+  Future<List<Meal>> filterByTags(List<String> tags) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return mockMeals.where((m) => tags.every(m.tags.contains)).toList();
+  }
+
+  Future<List<Meal>> suggestSwaps(Meal oldMeal) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return mockMeals.where((m) => m != oldMeal).toList();
+  }
+}

--- a/healthy_budget_coach/lib/data/repositories/workouts_repository.dart
+++ b/healthy_budget_coach/lib/data/repositories/workouts_repository.dart
@@ -1,0 +1,18 @@
+import '../mock_data.dart';
+
+class WorkoutsRepository {
+  Stream<List<Workout>> listWorkouts() async* {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    yield mockWorkouts;
+  }
+
+  Future<List<Workout>> filterByGoal(String goal) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return mockWorkouts.where((w) => w.goal == goal).toList();
+  }
+
+  Future<Workout?> quickStart() async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return mockWorkouts.isNotEmpty ? mockWorkouts.first : null;
+  }
+}

--- a/healthy_budget_coach/lib/main.dart
+++ b/healthy_budget_coach/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'theme/app_theme.dart';
+import 'core/ui/app_router.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,119 +9,13 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the MyApp.build method and use it to set our AppBar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      title: 'Healthy Budget Coach',
+      theme: AppTheme.light(null),
+      onGenerateRoute: AppRouter.onGenerateRoute,
+      initialRoute: '/',
     );
   }
 }

--- a/healthy_budget_coach/lib/theme/app_theme.dart
+++ b/healthy_budget_coach/lib/theme/app_theme.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static const _fallbackSeed = Color(0xFF006E1C);
+
+  static ThemeData light(ColorScheme? dynamicScheme) {
+    final colorScheme = dynamicScheme ??
+        ColorScheme.fromSeed(seedColor: _fallbackSeed, brightness: Brightness.light);
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      visualDensity: VisualDensity.adaptivePlatformDensity,
+      pageTransitionsTheme: const PageTransitionsTheme(builders: {
+        TargetPlatform.android: ZoomPageTransitionsBuilder(),
+        TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
+      }),
+      textTheme: _textTheme.apply(
+        bodyColor: colorScheme.onBackground,
+        displayColor: colorScheme.onBackground,
+      ),
+      dividerTheme: const DividerThemeData(space: 1),
+      chipTheme: ChipThemeData(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+        side: BorderSide(color: colorScheme.outlineVariant),
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+        showDragHandle: true,
+        backgroundColor: colorScheme.surface,
+      ),
+    );
+  }
+
+  static const _textTheme = TextTheme(
+    displayLarge: TextStyle(fontSize: 57, fontWeight: FontWeight.w400),
+    displayMedium: TextStyle(fontSize: 45, fontWeight: FontWeight.w400),
+    displaySmall: TextStyle(fontSize: 36, fontWeight: FontWeight.w400),
+    headlineLarge: TextStyle(fontSize: 32, fontWeight: FontWeight.w400),
+    headlineMedium: TextStyle(fontSize: 28, fontWeight: FontWeight.w400),
+    headlineSmall: TextStyle(fontSize: 24, fontWeight: FontWeight.w400),
+    titleLarge: TextStyle(fontSize: 22, fontWeight: FontWeight.w500),
+    titleMedium: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+    titleSmall: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+    bodyLarge: TextStyle(fontSize: 16, fontWeight: FontWeight.w400),
+    bodyMedium: TextStyle(fontSize: 14, fontWeight: FontWeight.w400),
+    bodySmall: TextStyle(fontSize: 12, fontWeight: FontWeight.w400),
+    labelLarge: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+    labelMedium: TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
+    labelSmall: TextStyle(fontSize: 11, fontWeight: FontWeight.w500),
+  );
+}
+

--- a/healthy_budget_coach/lib/ui/components/coach_card.dart
+++ b/healthy_budget_coach/lib/ui/components/coach_card.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class CoachCard extends StatelessWidget {
+  final IconData icon;
+  final String message;
+  final VoidCallback? onTap;
+  const CoachCard({super.key, required this.icon, required this.message, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: Icon(icon),
+        title: Text(message),
+        trailing: onTap != null ? FilledButton(onPressed: onTap, child: const Text('Go')) : null,
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/screens/screen_assistant.dart
+++ b/healthy_budget_coach/lib/ui/screens/screen_assistant.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class AssistantScreen extends StatefulWidget {
+  const AssistantScreen({super.key});
+
+  @override
+  State<AssistantScreen> createState() => _AssistantScreenState();
+}
+
+class _AssistantScreenState extends State<AssistantScreen> {
+  bool typing = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Assistant')),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                _bubble('Hello! How can I help?', DateTime.now().subtract(const Duration(minutes: 1))),
+                if (typing) _typingIndicator(),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  Widget _bubble(String text, DateTime time) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceVariant,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Text(text),
+          ),
+          const SizedBox(height: 4),
+          Text('${time.hour}:${time.minute.toString().padLeft(2, '0')}',
+              style: Theme.of(context).textTheme.bodySmall),
+        ],
+      ),
+    );
+  }
+
+  Widget _typingIndicator() {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          SizedBox(width: 4),
+          CircularProgressIndicator(strokeWidth: 2),
+          SizedBox(width: 8),
+          Text('Assistant is typing...'),
+        ],
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/screens/screen_dashboard.dart
+++ b/healthy_budget_coach/lib/ui/screens/screen_dashboard.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/meals_repository.dart';
+import '../../data/repositories/workouts_repository.dart';
+import '../../data/mock_data.dart';
+import '../widgets/budget_meter.dart';
+import '../widgets/meal_card.dart';
+import '../widgets/workout_card.dart';
+import '../components/coach_card.dart';
+import '../widgets/shimmer_box.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  final mealsRepo = MealsRepository();
+  final workoutsRepo = WorkoutsRepository();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: RefreshIndicator(
+        onRefresh: () async => setState(() {}),
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            const BudgetMeter(spent: 45, cap: 100),
+            const SizedBox(height: 16),
+            Text('Today\'s meals', style: Theme.of(context).textTheme.titleLarge),
+            StreamBuilder<List<Meal>>(
+              stream: mealsRepo.listMeals(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const ShimmerBox(height: 100, width: double.infinity);
+                }
+                return Column(
+                  children:
+                      snapshot.data!.map((m) => MealCard(meal: m)).toList(),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Text('Quick workouts', style: Theme.of(context).textTheme.titleLarge),
+            StreamBuilder<List<Workout>>(
+              stream: workoutsRepo.listWorkouts(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const ShimmerBox(height: 80, width: double.infinity);
+                }
+                return Column(
+                  children:
+                      snapshot.data!.map((w) => WorkoutCard(workout: w)).toList(),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            const CoachCard(
+              icon: Icons.savings,
+              message: 'Swap expensive items for cheaper ones',
+            ),
+            const CoachCard(
+              icon: Icons.fitness_center,
+              message: 'Short daily workouts keep energy high',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/screens/screen_deals.dart
+++ b/healthy_budget_coach/lib/ui/screens/screen_deals.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/deals_repository.dart';
+import '../../data/mock_data.dart';
+import '../widgets/price_chip.dart';
+import '../widgets/shimmer_box.dart';
+import '../widgets/empty_state.dart';
+
+class DealsScreen extends StatefulWidget {
+  const DealsScreen({super.key});
+
+  @override
+  State<DealsScreen> createState() => _DealsScreenState();
+}
+
+class _DealsScreenState extends State<DealsScreen> {
+  final repo = DealsRepository();
+  late Future<Map<String, List<Deal>>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = repo.groupByStore();
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _future = repo.groupByStore();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Deals')),
+      body: FutureBuilder<Map<String, List<Deal>>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: ShimmerBox(height: 100, width: double.infinity));
+          }
+          final map = snapshot.data!;
+          if (map.isEmpty) {
+            return EmptyState(message: 'No deals', onRetry: _refresh);
+          }
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: map.entries
+                  .map((e) => _buildStoreSection(context, e.key, e.value))
+                  .toList(),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildStoreSection(BuildContext context, String store, List<Deal> deals) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(store, style: Theme.of(context).textTheme.titleLarge),
+        ...deals.map((d) => ListTile(
+              title: Text(d.item),
+              trailing: PriceChip(price: d.price, oldPrice: d.oldPrice),
+              onTap: () {
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text('Selected ${d.item}')));
+              },
+            ))
+      ],
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/screens/screen_meals.dart
+++ b/healthy_budget_coach/lib/ui/screens/screen_meals.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/meals_repository.dart';
+import '../../data/mock_data.dart';
+import '../widgets/meal_card.dart';
+import '../widgets/shimmer_box.dart';
+import '../widgets/empty_state.dart';
+
+class MealsScreen extends StatefulWidget {
+  const MealsScreen({super.key});
+
+  @override
+  State<MealsScreen> createState() => _MealsScreenState();
+}
+
+class _MealsScreenState extends State<MealsScreen> {
+  final repo = MealsRepository();
+  String query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Meals')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              decoration: const InputDecoration(prefixIcon: Icon(Icons.search), hintText: 'Search meals'),
+              onChanged: (v) => setState(() => query = v.toLowerCase()),
+            ),
+          ),
+          Expanded(
+            child: StreamBuilder<List<Meal>>(
+              stream: repo.listMeals(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: ShimmerBox(height: 100, width: double.infinity));
+                }
+                final meals = snapshot.data!
+                    .where((m) => m.name.toLowerCase().contains(query))
+                    .toList();
+                if (meals.isEmpty) {
+                  return const EmptyState(message: 'No meals found');
+                }
+                return RefreshIndicator(
+                  onRefresh: () async => setState(() {}),
+                  child: ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: meals.map((m) => MealCard(meal: m)).toList(),
+                  ),
+                );
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/screens/screen_workouts.dart
+++ b/healthy_budget_coach/lib/ui/screens/screen_workouts.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/workouts_repository.dart';
+import '../../data/mock_data.dart';
+import '../widgets/workout_card.dart';
+import '../widgets/shimmer_box.dart';
+import '../widgets/empty_state.dart';
+
+class WorkoutsScreen extends StatefulWidget {
+  const WorkoutsScreen({super.key});
+
+  @override
+  State<WorkoutsScreen> createState() => _WorkoutsScreenState();
+}
+
+class _WorkoutsScreenState extends State<WorkoutsScreen> {
+  final repo = WorkoutsRepository();
+  String goal = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Workouts')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: DropdownButtonFormField<String>(
+              decoration: const InputDecoration(labelText: 'Goal'),
+              items: const [
+                DropdownMenuItem(value: '', child: Text('All')),
+                DropdownMenuItem(value: 'Fat loss', child: Text('Fat loss')),
+                DropdownMenuItem(value: 'Strength', child: Text('Strength')),
+                DropdownMenuItem(value: 'Recovery', child: Text('Recovery')),
+              ],
+              onChanged: (v) => setState(() => goal = v ?? ''),
+              value: goal,
+            ),
+          ),
+          Expanded(
+            child: StreamBuilder<List<Workout>>(
+              stream: repo.listWorkouts(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: ShimmerBox(height: 80, width: double.infinity));
+                }
+                var list = snapshot.data!;
+                if (goal.isNotEmpty) {
+                  list = list.where((w) => w.goal == goal).toList();
+                }
+                if (list.isEmpty) {
+                  return const EmptyState(message: 'No workouts');
+                }
+                return RefreshIndicator(
+                  onRefresh: () async => setState(() {}),
+                  child: ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: list.map((w) => WorkoutCard(workout: w)).toList(),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final quick = await repo.quickStart();
+          if (quick != null) {
+            // show snackbar
+            if (context.mounted) {
+              ScaffoldMessenger.of(context)
+                  .showSnackBar(SnackBar(content: Text('Starting ${quick.title}')));
+            }
+          }
+        },
+        child: const Icon(Icons.play_arrow),
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/app_badges.dart
+++ b/healthy_budget_coach/lib/ui/widgets/app_badges.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class AppBadge extends StatelessWidget {
+  final String label;
+  const AppBadge(this.label, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 4),
+      child: Chip(label: Text(label)),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/budget_meter.dart
+++ b/healthy_budget_coach/lib/ui/widgets/budget_meter.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../../core/ui/formatters.dart';
+
+class BudgetMeter extends StatelessWidget {
+  final double spent;
+  final double cap;
+  const BudgetMeter({super.key, required this.spent, required this.cap});
+
+  @override
+  Widget build(BuildContext context) {
+    final ratio = (spent / cap).clamp(0.0, 1.0);
+    Color color;
+    if (ratio < 0.5) {
+      color = Colors.green;
+    } else if (ratio < 0.8) {
+      color = Colors.amber;
+    } else {
+      color = Colors.red;
+    }
+    return Tooltip(
+      message: '${priceFormatter(spent)} / ${priceFormatter(cap)}',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          LinearProgressIndicator(value: ratio, color: color),
+          const SizedBox(height: 4),
+          Text('${(ratio * 100).toStringAsFixed(0)}% used',
+              style: Theme.of(context).textTheme.bodySmall),
+        ],
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/empty_state.dart
+++ b/healthy_budget_coach/lib/ui/widgets/empty_state.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class EmptyState extends StatelessWidget {
+  final String message;
+  final VoidCallback? onRetry;
+  const EmptyState({super.key, required this.message, this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.inbox, size: 48),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          if (onRetry != null)
+            TextButton(onPressed: onRetry, child: const Text('Retry')),
+        ],
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/error_state.dart
+++ b/healthy_budget_coach/lib/ui/widgets/error_state.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ErrorState extends StatelessWidget {
+  final String message;
+  final VoidCallback? onRetry;
+  const ErrorState({super.key, required this.message, this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 48),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          if (onRetry != null)
+            TextButton(onPressed: onRetry, child: const Text('Retry')),
+        ],
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/meal_card.dart
+++ b/healthy_budget_coach/lib/ui/widgets/meal_card.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import '../../core/ui/formatters.dart';
+import '../../data/mock_data.dart';
+import 'price_chip.dart';
+import 'swap_sheet.dart';
+import 'app_badges.dart';
+
+class MealCard extends StatelessWidget {
+  final Meal meal;
+  const MealCard({super.key, required this.meal});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(child: Text(meal.name, style: Theme.of(context).textTheme.titleMedium)),
+                PriceChip(price: meal.price),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(macroFormatter(meal.protein, 'protein')),
+            Text(kcalFormatter(meal.calories)),
+            Wrap(children: meal.tags.map((t) => AppBadge(t)).toList()),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () async {
+                  final swap = await showModalBottomSheet<Meal>(
+                    context: context,
+                    builder: (_) => SwapSheet(meal: meal),
+                  );
+                  if (swap != null) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Swapped with ${swap.name}')),
+                    );
+                  }
+                },
+                child: const Text('Cheaper swap'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/price_chip.dart
+++ b/healthy_budget_coach/lib/ui/widgets/price_chip.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../../core/ui/formatters.dart';
+
+class PriceChip extends StatelessWidget {
+  final double price;
+  final double? oldPrice;
+  const PriceChip({super.key, required this.price, this.oldPrice});
+
+  @override
+  Widget build(BuildContext context) {
+    final current = priceFormatter(price);
+    final old = oldPrice != null ? priceFormatter(oldPrice!) : null;
+    final percent = oldPrice != null ? (((oldPrice! - price) / oldPrice!) * 100).round() : null;
+    return Chip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(current, semanticsLabel: 'price $current'),
+          if (old != null) ...[
+            const SizedBox(width: 4),
+            Text(old, style: const TextStyle(decoration: TextDecoration.lineThrough)),
+            if (percent != null) ...[
+              const SizedBox(width: 4),
+              Text('-$percent%'),
+            ]
+          ]
+        ],
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/shimmer_box.dart
+++ b/healthy_budget_coach/lib/ui/widgets/shimmer_box.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class ShimmerBox extends StatefulWidget {
+  final double height;
+  final double? width;
+  const ShimmerBox({super.key, required this.height, this.width});
+
+  @override
+  State<ShimmerBox> createState() => _ShimmerBoxState();
+}
+
+class _ShimmerBoxState extends State<ShimmerBox>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: Tween(begin: 0.3, end: 0.7).animate(_controller),
+      child: Container(
+        height: widget.height,
+        width: widget.width,
+        decoration: BoxDecoration(
+          color: Colors.grey.shade300,
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/swap_sheet.dart
+++ b/healthy_budget_coach/lib/ui/widgets/swap_sheet.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../../data/mock_data.dart';
+import '../../data/repositories/meals_repository.dart';
+import '../../core/ui/formatters.dart';
+import 'price_chip.dart';
+import 'shimmer_box.dart';
+
+class SwapSheet extends StatefulWidget {
+  final Meal meal;
+  const SwapSheet({super.key, required this.meal});
+
+  @override
+  State<SwapSheet> createState() => _SwapSheetState();
+}
+
+class _SwapSheetState extends State<SwapSheet> {
+  final repo = MealsRepository();
+  late Future<List<Meal>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = repo.suggestSwaps(widget.meal);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<Meal>>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: ShimmerBox(height: 80, width: double.infinity),
+          );
+        }
+        final meals = snapshot.data!;
+        return ListView.builder(
+          itemCount: meals.length,
+          itemBuilder: (context, i) {
+            final meal = meals[i];
+            final priceDelta = widget.meal.price - meal.price;
+            final proteinDelta = meal.protein - widget.meal.protein;
+            final kcalDelta = meal.calories - widget.meal.calories;
+            return ListTile(
+              title: Text(meal.name),
+              subtitle: Text(
+                '${priceFormatter(priceDelta)} • ${macroFormatter(proteinDelta, 'protein')} • ${kcalFormatter(kcalDelta)}',
+              ),
+              trailing: PriceChip(price: meal.price),
+              onTap: () => Navigator.pop(context, meal),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/healthy_budget_coach/lib/ui/widgets/workout_card.dart
+++ b/healthy_budget_coach/lib/ui/widgets/workout_card.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import '../../data/mock_data.dart';
+import '../../core/ui/formatters.dart';
+import 'app_badges.dart';
+
+class WorkoutCard extends StatelessWidget {
+  final Workout workout;
+  const WorkoutCard({super.key, required this.workout});
+
+  @override
+  Widget build(BuildContext context) {
+    final intensityLabels = ['Low', 'Med', 'High'];
+    final intensity = intensityLabels[(workout.intensity - 1).clamp(0, 2)];
+    final kcalPerMin = (workout.intensity * 5);
+    return Card(
+      child: ListTile(
+        title: Text(workout.title),
+        subtitle: Text('${workout.goal} • ${kcalFormatter(kcalPerMin)} / min'),
+        trailing: AppBadge(intensity),
+      ),
+    );
+  }
+}

--- a/healthy_budget_coach/pubspec.yaml
+++ b/healthy_budget_coach/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Material 3 theme with dynamic color fallback and rounded surfaces
- introduce simple router, formatters, and mock repositories
- build dashboard, meals, deals, workouts, and assistant screens with reusable widgets

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format healthy_budget_coach/lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adde0dcb84832a9d53ca517d0961d8